### PR TITLE
Helpful error message for South users

### DIFF
--- a/constance/backends/database/migrations/__init__.py
+++ b/constance/backends/database/migrations/__init__.py
@@ -1,0 +1,21 @@
+"""
+Django migrations for constance database backend
+
+This package does not contain South migrations.  South migrations can be found
+in the ``south_migrations`` package.
+"""
+
+SOUTH_ERROR_MESSAGE = """\n
+For South support, customize the SOUTH_MIGRATION_MODULES setting like so:
+
+    SOUTH_MIGRATION_MODULES = {
+        'database': 'constance.backends.database.south_migrations',
+    }
+"""
+
+# Ensure the user is not using Django 1.6 or below with South
+try:
+    from django.db import migrations  # noqa
+except ImportError:
+    from django.core.exceptions import ImproperlyConfigured
+    raise ImproperlyConfigured(SOUTH_ERROR_MESSAGE)


### PR DESCRIPTION
Add code to display a message with instructions on how to enable South migrations for those still using it.