### PR TITLE
[Fixes #93] Make models.py 1.8 compatible

### DIFF
--- a/constance/models.py
+++ b/constance/models.py
@@ -1,4 +1,5 @@
 from django.db.models import signals
+from django import VERSION
 
 
 def create_perm(app, created_models, verbosity, db, **kwargs):
@@ -10,10 +11,11 @@ def create_perm(app, created_models, verbosity, db, **kwargs):
     from django.contrib.contenttypes.models import ContentType
 
     if ContentType._meta.installed and Permission._meta.installed:
+        extra = {} if VERSION >= (1, 8) else {'name': 'config'}
         content_type, created = ContentType.objects.get_or_create(
-            name='config',
             app_label='constance',
-            model='config')
+            model='config',
+            **extra)
 
         permission, created = Permission.objects.get_or_create(
             name='Can change config',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
     py26-django-14,
     py27-django-14,
     {py26,py27,py32,py33,py34,pypy}-django-{15,16},
-    {py27,py32,py33,py34,pypy}-django-{17,master}
+    {py27,py32,py33,py34,pypy}-django-17
+    {py27,py33,py34,pypy}-django-master
 
 [testenv]
 basepython =


### PR DESCRIPTION
Simple fix for the dropping of 'name' from ContentType in Django 1.8