### PR TITLE
Add override_config class for testing config values

### DIFF
--- a/constance/test/__init__.py
+++ b/constance/test/__init__.py
@@ -1,0 +1,1 @@
+from .utils import override_config

--- a/constance/test/utils.py
+++ b/constance/test/utils.py
@@ -1,0 +1,75 @@
+from functools import wraps
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from .. import config
+
+__all__ = ('override_config',)
+
+
+class override_config(override_settings):
+    """Decorator to modify constance setting for TestCase.
+
+    Based on django.test.utils.override_settings.
+    """
+    def __init__(self, **kwargs):
+        super(override_config, self).__init__(**kwargs)
+        self.original_values = {}
+
+    def __call__(self, test_func):
+        """Modify the decorated function to override config values."""
+        if isinstance(test_func, type):
+            if not issubclass(test_func, SimpleTestCase):
+                raise Exception(
+                    "Only subclasses of Django SimpleTestCase can be "
+                    "decorated with override_config")
+            return self.modify_test_case(test_func)
+        else:
+            @wraps(test_func)
+            def inner(*args, **kwargs):
+                with self:
+                    return test_func(*args, **kwargs)
+        return inner
+
+    def modify_test_case(self, test_case):
+        """Override the config by modifying TestCase methods.
+
+        This method follows the Django <= 1.6 method of overriding the
+        _pre_setup and _post_teardown hooks rather than modifying the TestCase
+        itself.
+        """
+        original_pre_setup = test_case._pre_setup
+        original_post_teardown = test_case._post_teardown
+
+        def _pre_setup(inner_self):
+            self.enable()
+            original_pre_setup(inner_self)
+
+        def _post_teardown(inner_self):
+            original_post_teardown(inner_self)
+            self.disable()
+
+        test_case._pre_setup = _pre_setup
+        test_case._post_teardown = _post_teardown
+
+        return test_case
+
+    def enable(self):
+        """Store original config values and set overridden values."""
+        # Store the original values to an instance variable
+        for config_key in self.options.keys():
+            self.original_values[config_key] = getattr(config, config_key)
+
+        # Update config with the overriden values
+        self.unpack_values(self.options)
+
+    def disable(self):
+        """Set original values to the config."""
+        self.unpack_values(self.original_values)
+
+    @staticmethod
+    def unpack_values(options):
+        """Unpack values from the given dict to config."""
+        for name, value in options.items():
+            setattr(config, name, value)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,6 +133,7 @@ More documentation
    :maxdepth: 2
 
    backends
+   testing
    changes
 
 Indices and tables

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,41 @@
+Testing
+=======
+
+Testing how your app behaves with different config values is achieved with the
+:class:`override_config` class. This intentionally mirrors the use of Django's
+:class:`~django.test.override_setting`.
+
+.. py:class:: override_config(**kwargs)
+
+    Replace key-value pairs in config.
+
+
+Usage
+~~~~~
+
+It can be used as a decorator at the :class:`~django.test.TestCase` level, the
+method level and also as a
+`context manager <https://www.python.org/dev/peps/pep-0343/>`_.
+
+.. code-block:: python
+
+    from constance import config
+    from constance.test import override_config
+
+    from django.test import TestCase
+
+
+    @override_config(YOUR_NAME="Arthur of Camelot")
+    class ExampleTestCase(TestCase):
+
+        def test_what_is_your_name(self):
+            self.assertEqual(config.YOUR_NAME, "Arthur of Camelot")
+
+        @override_config(YOUR_QUEST="To find the Holy Grail")
+        def test_what_is_your_quest(self):
+            self.assertEqual(config.YOUR_QUEST, "To find the Holy Grail")
+
+        def test_what_is_your_favourite_color(self):
+            with override_config(YOUR_FAVOURITE_COLOR="Blue?"):
+                self.assertEqual(config.YOUR_FAVOURITE_COLOR, "Blue?")
+

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from constance import config
+from constance.test import override_config
+
+
+class OverrideConfigFunctionDecoratorTestCase(TestCase):
+    """Test that the override_config decorator works correctly.
+
+    Test usage of override_config on test method and as context manager.
+    """
+    def test_default_value_is_true(self):
+        """Assert that the default value of config.BOOL_VALUE is True."""
+        self.assertTrue(config.BOOL_VALUE)
+
+    @override_config(BOOL_VALUE=False)
+    def test_override_config_on_method_changes_config_value(self):
+        """Assert that the method decorator changes config.BOOL_VALUE."""
+        self.assertFalse(config.BOOL_VALUE)
+
+    def test_override_config_as_context_manager_changes_config_value(self):
+        """Assert that the context manager changes config.BOOL_VALUE."""
+        with override_config(BOOL_VALUE=False):
+            self.assertFalse(config.BOOL_VALUE)
+
+        self.assertTrue(config.BOOL_VALUE)
+
+
+@override_config(BOOL_VALUE=False)
+class OverrideConfigClassDecoratorTestCase(TestCase):
+    """Test that the override_config decorator works on classes."""
+    def test_override_config_on_class_changes_config_value(self):
+        """Asser that the class decorator changes config.BOOL_VALUE."""
+        self.assertFalse(config.BOOL_VALUE)


### PR DESCRIPTION
This PR adds an `override_config` decorator that mirrors Django's `override_settings` decorator for use in testing. It allows users of the app to easily test how their application responds to changes in the values of `config` parameters.

I have added a `TestCase` and confirmed the functionality across the supported Python and Django versions using tox locally. This PR should introduce no more failing tests than currently exist in the master branch.

I've also updated the docs accordingly. Thanks for taking a look!