### PR TITLE
Some fixes for recent Djangos

### DIFF
--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -1,6 +1,12 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
-from django.core.cache import get_cache
+
+try:
+    from django.core.cache import get_cache
+except ImportError:
+    from django.core.cache import caches
+    def get_cache(name):
+        return caches[name]
 
 try:
     from django.core.cache.backends.locmem import LocMemCache

--- a/constance/models.py
+++ b/constance/models.py
@@ -1,7 +1,7 @@
 from django.db.models import signals
 
 
-def create_perm(app, created_models, verbosity, db, **kwargs):
+def create_perm(*args, **kwargs):
     """
     Creates a fake content type and permission
     to be able to check for permissions
@@ -11,7 +11,6 @@ def create_perm(app, created_models, verbosity, db, **kwargs):
 
     if ContentType._meta.installed and Permission._meta.installed:
         content_type, created = ContentType.objects.get_or_create(
-            name='config',
             app_label='constance',
             model='config')
 
@@ -21,4 +20,7 @@ def create_perm(app, created_models, verbosity, db, **kwargs):
             codename='change_config')
 
 
-signals.post_syncdb.connect(create_perm, dispatch_uid="constance.create_perm")
+if hasattr(signals, 'post_syncdb'):
+    signals.post_syncdb.connect(create_perm, dispatch_uid="constance.create_perm")
+else:
+    signals.post_migrate.connect(create_perm, dispatch_uid="constance.create_perm")

--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load admin_static admin_list i18n %}
-{% load url from future %}
 
 
 {% block extrastyle %}

--- a/constance/utils.py
+++ b/constance/utils.py
@@ -1,4 +1,7 @@
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 def import_module_attr(path):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
     py26-django-14,
     py27-django-14,
     {py26,py27,py32,py33,py34,pypy}-django-{15,16},
-    {py27,py32,py33,py34,pypy}-django-{17,master}
+    {py27,py32,py33,py34,pypy}-django-{17,18}
+    {py27,py34,py35,pypy}-django-{master}
 
 [testenv]
 basepython =
@@ -12,6 +13,7 @@ basepython =
     py32: python3.2
     py33: python3.3
     py34: python3.4
+    py35: python3.5
     pypy: pypy
 deps =
     redis
@@ -23,6 +25,7 @@ deps =
     django-15: Django>=1.5,<1.6
     django-16: Django>=1.6,<1.7
     django-17: Django>=1.7,<1.8
+    django-18: Django>=1.8,<1.9
     django-master: https://github.com/django/django/archive/master.zip
 usedevelop = true
 commands =


### PR DESCRIPTION
* Add Django 1.8 to test environments in tox.ini
* Update python versions supported by Django master in tox.ini
* Don't load 'url' from template library 'future' - it is no longer
  available in Django master, and is not needed in Django 1.4 and later,
  which is as far back as django-constance tests
  * get_cache dropped from Django master
  * post_syncdb signal dropped
  * django.utils.importlib dropped

There are still errors on some environments that I didn't try to
address:

* coverage seems broken on py32
* django-master seems currently broken on py27 (non-ASCII character somewhere,
I expect django-master will be fixed soon since they still claim py27 support)
* django14 seems broken: "NoReverseMatch: u"'admin" is not a registered
namespace"