### PR TITLE
Work around for pip bug w/ Django zips

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     django-15: Django>=1.5,<1.6
     django-16: Django>=1.6,<1.7
     django-17: Django>=1.7,<1.8
-    django-master: https://github.com/django/django/archive/master.zip
+    django-master: https://github.com/django/django/archive/master.tar.gz
 usedevelop = true
 commands =
     coverage run {envbindir}/django-admin.py test --settings=tests.settings -v2


### PR DESCRIPTION
Should fix #110

Workaround for the partially-fixed pypa/pip#1473, letting tests on django master work again.