### PR TITLE
Compatibility changes.

### DIFF
--- a/constance/admin.py
+++ b/constance/admin.py
@@ -4,6 +4,7 @@ import hashlib
 from operator import itemgetter
 
 from django import forms
+from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin import widgets
 from django.contrib.admin.options import csrf_protect_m
@@ -13,18 +14,9 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response
 from django.template.context import RequestContext
 from django.utils import six
+from django.utils.encoding import smart_bytes
 from django.utils.formats import localize
 from django.utils.translation import ugettext_lazy as _
-
-try:
-    from django.utils.encoding import smart_bytes
-except ImportError:
-    from django.utils.encoding import smart_str as smart_bytes
-
-try:
-    from django.conf.urls import patterns, url
-except ImportError:  # Django < 1.4
-    from django.conf.urls.defaults import patterns, url
 
 
 from . import LazyConfig, settings
@@ -97,14 +89,14 @@ class ConstanceAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.module_name
-        return patterns('',
+        return [
             url(r'^$',
                 self.admin_site.admin_view(self.changelist_view),
                 name='%s_%s_changelist' % info),
             url(r'^$',
                 self.admin_site.admin_view(self.changelist_view),
                 name='%s_%s_add' % info),
-        )
+        ]
 
     @csrf_protect_m
     def changelist_view(self, request, extra_context=None):

--- a/constance/apps.py
+++ b/constance/apps.py
@@ -5,3 +5,6 @@ from django.utils.translation import ugettext_lazy as _
 class ConstanceConfig(AppConfig):
     name = 'constance'
     verbose_name = _('Constance')
+
+    def ready(self):
+        from . import connect

--- a/constance/backends/database/__init__.py
+++ b/constance/backends/database/__init__.py
@@ -1,11 +1,7 @@
+from django.core.cache.backends.locmem import LocMemCache
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_save
-from django.core.cache import get_cache
-
-try:
-    from django.core.cache.backends.locmem import LocMemCache
-except ImportError:
-    from django.core.cache.backends.locmem import CacheClass as LocMemCache
+from django.core.cache import caches
 
 from .. import Backend
 from ... import settings
@@ -25,7 +21,7 @@ class DatabaseBackend(Backend):
                 "correctly. Make sure it's in your INSTALLED_APPS setting.")
 
         if settings.DATABASE_CACHE_BACKEND:
-            self._cache = get_cache(settings.DATABASE_CACHE_BACKEND)
+            self._cache = caches[settings.DATABASE_CACHE_BACKEND]
             if isinstance(self._cache, LocMemCache):
                 raise ImproperlyConfigured(
                     "The CONSTANCE_DATABASE_CACHE_BACKEND setting refers to a "

--- a/constance/connect.py
+++ b/constance/connect.py
@@ -1,7 +1,12 @@
-from django.db.models import signals
+import django
+from django.db.models.signals import post_migrate
 
+if django.VERSION >= (1, 8):
+    CONTENT_TYPE_EXTRA = {}
+else:
+    CONTENT_TYPE_EXTRA = {'name': 'config'}
 
-def create_perm(app, created_models, verbosity, db, **kwargs):
+def create_perm(*args, **kwargs):
     """
     Creates a fake content type and permission
     to be able to check for permissions
@@ -11,9 +16,9 @@ def create_perm(app, created_models, verbosity, db, **kwargs):
 
     if ContentType._meta.installed and Permission._meta.installed:
         content_type, created = ContentType.objects.get_or_create(
-            name='config',
             app_label='constance',
-            model='config')
+            model='config',
+            **CONTENT_TYPE_EXTRA)
 
         permission, created = Permission.objects.get_or_create(
             name='Can change config',
@@ -21,4 +26,4 @@ def create_perm(app, created_models, verbosity, db, **kwargs):
             codename='change_config')
 
 
-signals.post_syncdb.connect(create_perm, dispatch_uid="constance.create_perm")
+post_migrate.connect(create_perm, dispatch_uid="constance.create_perm")

--- a/constance/templates/admin/constance/change_list.html
+++ b/constance/templates/admin/constance/change_list.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load admin_static admin_list i18n %}
-{% load url from future %}
 
 
 {% block extrastyle %}

--- a/constance/utils.py
+++ b/constance/utils.py
@@ -1,5 +1,4 @@
-from django.utils.importlib import import_module
-
+from importlib import import_module
 
 def import_module_attr(path):
     package, module = path.rsplit('.', 1)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -44,3 +44,10 @@ class TestAdmin(TestCase):
 
         response = self.options.changelist_view(request, {})
         self.assertEqual(response.status_code, 200)
+
+    def test_str(self):
+        from django.utils import six
+        from django.contrib.contenttypes.models import ContentType
+        ct = ContentType.objects.get(app_label='constance', model='config')
+
+        self.assertEqual(six.text_type(ct), 'config')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,11 +1,8 @@
 from django.contrib import admin
 
-try:
-    from django.conf.urls import patterns, include
-except ImportError:
-    from django.conf.urls.defaults import patterns, include
+from django.conf.urls import url, include
 
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,21 @@
 [tox]
 envlist =
-    py26-django-14,
-    py27-django-14,
-    {py26,py27,py32,py33,py34,pypy}-django-{15,16},
-    {py27,py32,py33,py34,pypy}-django-{17,master}
+    {py27,py33,py34,pypy}-django-{17,18},
+    {py27,py34,pypy}-django-{master}
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
-    py32: python3.2
     py33: python3.3
     py34: python3.4
+    py35: python3.5
     pypy: pypy
 deps =
     redis
     coverage
     django-picklefield
-    py26: unittest2
-    django-{14,15}: django-discover-runner
-    django-14: Django>=1.4,<1.5
-    django-15: Django>=1.5,<1.6
-    django-16: Django>=1.6,<1.7
     django-17: Django>=1.7,<1.8
+    django-18: Django>=1.8,<1.9
     django-master: https://github.com/django/django/archive/master.zip
 usedevelop = true
 commands =


### PR DESCRIPTION
Drop python 2.6
Drop Django 1.4, 1.5, 1.6
Remove models.py under constance and move to an appconfig imported file.

This is a bit more aggressive of a compatibility change compared to previous PR's.